### PR TITLE
Feat/カードコンポーネントサイズ変更

### DIFF
--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,9 +1,6 @@
 
-:root{
-    --cardWidth: 100%;
-}
-.card {
-    width: var(--cardWidth);  
+
+.card { 
     border: 1px solid #ccc;
     background-color: #fff;
     text-decoration: none;

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,6 +1,5 @@
-
-
 .card { 
+    max-width: 100%;
     border: 1px solid #ccc;
     background-color: #fff;
     text-decoration: none;

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,6 +1,9 @@
 
+:root{
+    --cardWidth: 100%;
+}
 .card {
-    width: 100%;  
+    width: var(--cardWidth);  
     border: 1px solid #ccc;
     background-color: #fff;
     text-decoration: none;

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -13,7 +13,7 @@ export default {
     to: { control: 'text' },
     imageSrc: { control: 'text' },
     imageAlt: { control: 'text' },
-    cardWidth: {control: 'text'},
+    cardWidth: { control: 'text' },
   },
 } as Meta;
 
@@ -29,5 +29,5 @@ Default.args = {
   to: '/',
   imageSrc: '/images/maximum-card.png',
   imageAlt: 'maximum',
-  cardWidth: '100%'
+  cardWidth: '100%',
 };

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -13,6 +13,7 @@ export default {
     to: { control: 'text' },
     imageSrc: { control: 'text' },
     imageAlt: { control: 'text' },
+    cardWidth: {control: 'text'},
   },
 } as Meta;
 
@@ -28,4 +29,5 @@ Default.args = {
   to: '/',
   imageSrc: '/images/maximum-card.png',
   imageAlt: 'maximum',
+  cardWidth: '100%'
 };

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Components/Card',
   component: Card,
   argTypes: {
-    customStyle: {control: 'object'},
+    customStyle: { control: 'object' },
     title: { control: 'text' },
     content: { control: 'text' },
     date: { control: 'text' },
@@ -22,7 +22,7 @@ export const Default = Template.bind({});
 
 Default.args = {
   customStyle: {
-    width: '100%'
+    width: '100%',
   },
   title: 'OOOOOOOOOOOOOOOOOOOOOOOOOO',
   content:

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Components/Card',
   component: Card,
   argTypes: {
-    customStyle: { control: 'object' },
+    style: { control: 'object' },
     title: { control: 'text' },
     content: { control: 'text' },
     date: { control: 'text' },
@@ -21,7 +21,7 @@ const Template: StoryFn<typeof Card> = (args) => <Card {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  customStyle: {
+  style: {
     width: '100%',
   },
   title: 'OOOOOOOOOOOOOOOOOOOOOOOOOO',

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Components/Card',
   component: Card,
   argTypes: {
+    customStyle: {control: 'object'},
     title: { control: 'text' },
     content: { control: 'text' },
     date: { control: 'text' },
@@ -13,7 +14,6 @@ export default {
     to: { control: 'text' },
     imageSrc: { control: 'text' },
     imageAlt: { control: 'text' },
-    cardWidth: { control: 'text' },
   },
 } as Meta;
 
@@ -21,6 +21,9 @@ const Template: StoryFn<typeof Card> = (args) => <Card {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
+  customStyle: {
+    width: '100%'
+  },
   title: 'OOOOOOOOOOOOOOOOOOOOOOOOOO',
   content:
     'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -29,5 +32,4 @@ Default.args = {
   to: '/',
   imageSrc: '/images/maximum-card.png',
   imageAlt: 'maximum',
-  cardWidth: '100%',
 };

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import style from './Card.module.css';
 
 interface CardProps {
-  customStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   title: string;
   content: string;
   date: string;
@@ -13,7 +13,7 @@ interface CardProps {
   imageAlt: string;
 }
 const Card: React.FC<CardProps> = ({
-  customStyle,
+  style: customStyle,
   title,
   content,
   date,

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -23,7 +23,12 @@ const Card: React.FC<CardProps> = ({
   cardWidth,
 }) => {
   //widthとして当てはまらない値の場合100%にする
-  const width = /^(\d+(\.\d+)?%|auto|inherit|initial|unset|fit-content|max-content|min-content|\d+(\.\d+)?(px|em|rem|cm|mm|in|pt|pc))$/.test(cardWidth) ? cardWidth : '100%';
+  const width =
+    /^(\d+(\.\d+)?%|auto|inherit|initial|unset|fit-content|max-content|min-content|\d+(\.\d+)?(px|em|rem|cm|mm|in|pt|pc))$/.test(
+      cardWidth,
+    )
+      ? cardWidth
+      : '100%';
 
   return (
     <Link href={to} className={style.card} style={{ width }}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, {useState} from 'react';
+import React from 'react';
 import style from './Card.module.css';
 
 interface CardProps {
@@ -22,8 +22,11 @@ const Card: React.FC<CardProps> = ({
   imageAlt,
   cardWidth,
 }) => {
+  //widthとして当てはまらない値の場合100%にする
+  const width = /^(\d+(\.\d+)?%|auto|inherit|initial|unset|fit-content|max-content|min-content|\d+(\.\d+)?(px|em|rem|cm|mm|in|pt|pc))$/.test(cardWidth) ? cardWidth : '100%';
+
   return (
-    <Link href={to} className={style.card} style={{ width: cardWidth}}>
+    <Link href={to} className={style.card} style={{ width }}>
       <div className={style.img}>
         <img className={style.img} src={imageSrc} alt={imageAlt} />
         <div className={style.box}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import style from './Card.module.css';
 
 interface CardProps {
-  customStyle?: React.CSSProperties | undefined;
+  customStyle?: React.CSSProperties;
   title: string;
   content: string;
   date: string;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -24,9 +24,9 @@ const Card: React.FC<CardProps> = ({
 }) => {
   //widthとして当てはまらない値の場合100%にする
   const width =
-  /^(\d+(\.\d+)?(%|px|em|rem|cm|mm|in|pt|pc)|auto|inherit|initial|unset|fit-content|max-content|min-content)$/.test(
-    cardWidth
-  )
+    /^(\d+(\.\d+)?(%|px|em|rem|cm|mm|in|pt|pc)|auto|inherit|initial|unset|fit-content|max-content|min-content)$/.test(
+      cardWidth,
+    )
       ? cardWidth
       : '100%';
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -24,9 +24,9 @@ const Card: React.FC<CardProps> = ({
 }) => {
   //widthとして当てはまらない値の場合100%にする
   const width =
-    /^(\d+(\.\d+)?%|auto|inherit|initial|unset|fit-content|max-content|min-content|\d+(\.\d+)?(px|em|rem|cm|mm|in|pt|pc))$/.test(
-      cardWidth,
-    )
+  /^(\d+(\.\d+)?(%|px|em|rem|cm|mm|in|pt|pc)|auto|inherit|initial|unset|fit-content|max-content|min-content)$/.test(
+    cardWidth
+  )
       ? cardWidth
       : '100%';
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,6 +10,7 @@ interface CardProps {
   to: string;
   imageSrc: string;
   imageAlt: string;
+  cardWidth: string;
 }
 const Card: React.FC<CardProps> = ({
   title,
@@ -19,6 +20,7 @@ const Card: React.FC<CardProps> = ({
   to,
   imageSrc,
   imageAlt,
+  cardWidth,
 }) => {
   return (
     <Link href={to} className={style.card}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import style from './Card.module.css';
 
 interface CardProps {
+  customStyle?: React.CSSProperties | undefined;
   title: string;
   content: string;
   date: string;
@@ -10,9 +11,9 @@ interface CardProps {
   to: string;
   imageSrc: string;
   imageAlt: string;
-  cardWidth: string;
 }
 const Card: React.FC<CardProps> = ({
+  customStyle,
   title,
   content,
   date,
@@ -20,18 +21,9 @@ const Card: React.FC<CardProps> = ({
   to,
   imageSrc,
   imageAlt,
-  cardWidth,
 }) => {
-  //widthとして当てはまらない値の場合100%にする
-  const width =
-    /^(\d+(\.\d+)?(%|px|em|rem|cm|mm|in|pt|pc)|auto|inherit|initial|unset|fit-content|max-content|min-content)$/.test(
-      cardWidth,
-    )
-      ? cardWidth
-      : '100%';
-
   return (
-    <Link href={to} className={style.card} style={{ width }}>
+    <Link href={to} className={style.card} style={customStyle}>
       <div className={style.img}>
         <img className={style.img} src={imageSrc} alt={imageAlt} />
         <div className={style.box}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React from 'react';
+import React, {useState} from 'react';
 import style from './Card.module.css';
 
 interface CardProps {
@@ -23,7 +23,7 @@ const Card: React.FC<CardProps> = ({
   cardWidth,
 }) => {
   return (
-    <Link href={to} className={style.card}>
+    <Link href={to} className={style.card} style={{ width: cardWidth}}>
       <div className={style.img}>
         <img className={style.img} src={imageSrc} alt={imageAlt} />
         <div className={style.box}>


### PR DESCRIPTION
縦幅はもともと自動だったので、widthのみ変更できるようにしました。正しくない値が入った場合には100%になるようになっているはずです。
よろしくお願いします。